### PR TITLE
Allow the plugin to work on non git projects.

### DIFF
--- a/src/main/java/org/jpos/gradle/JPOSPlugin.java
+++ b/src/main/java/org/jpos/gradle/JPOSPlugin.java
@@ -274,9 +274,12 @@ public class JPOSPlugin implements Plugin<Project> {
     @SuppressWarnings("unchecked")
     private void configureJar (Project project) {
         project.getTasks().getByName("jar").dependsOn(
-          project.getTasks().getByName("createBuildTimestamp"),
-          project.getTasks().getByName("createGitRevision")
+            project.getTasks().getByName("createBuildTimestamp")
         );
+        boolean ignoreGit = project.hasProperty("ignoreGit") && Boolean.parseBoolean((String) project.property("ignoreGit")); 
+        if (!ignoreGit) {
+            project.getTasks().getByName("jar").dependsOn(project.getTasks().getByName("createGitRevision")); 
+        }
         Attributes attr = ((Jar)project.getTasks().getByName("jar")).getManifest().getAttributes();
 
         attr.put ("Implementation-Title",  project.getName());


### PR DESCRIPTION
A project property was added to let the project avoid dependency of jar task on `createGitRevision` task.

This is an option for issue #5.