### PR TITLE
Support for gradle 8 and extension object

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ In order to use the jPOS APP Plugin
 
 1. Add to your `build.gradle`
 
-```
+```groovy
 plugins {
     id 'org.jpos.jposapp' version '0.0.3'
 }
@@ -10,7 +10,7 @@ plugins {
 
 2. Add to your `settings.gradle`
 
-```
+```groovy
 pluginManagement {
     repositories {
         maven { url = uri('https://jpos.org/maven') }
@@ -21,3 +21,30 @@ pluginManagement {
 
 See [Gradle Plugin Repository](https://plugins.gradle.org/plugin/org.jpos.jposapp) for latest version.
 
+
+## Plugin configuration
+
+To change the default values of the plugin, you can use the `jpos` property:
+
+```groovy
+jpos {
+    target = "devel"                        // string, which configuration file read from the root. default "devel" (devel.properties)
+    addGitRevision = true                   // boolean, if the file revision.properties should be created
+    addBuildTime = true                     // boolean, if the file buildinfo.properties should be created
+    archiveJarName = "jpos.jar"             // string, the name of the jar, default '${project}-${version}.jar'
+    archiveWarName = "jpos.war"             // string, the name of the war, default '${project}-${version}.war'
+    installDir = build/install/jpos         // string, the default install dir, default to '${build}/install/${project}'
+    distDir = src/dist                      // string, path to the distribution folder
+}
+```
+
+For example, if we want to create an inmutable build file, we can disable the git and build time info:
+
+```groovy
+jpos {
+    addGitRevision = false
+    addBuildTime false
+}
+```
+
+This will generate always the same jar (and dist folder)

--- a/src/main/java/org/jpos/gradle/JPOSPluginExtension.java
+++ b/src/main/java/org/jpos/gradle/JPOSPluginExtension.java
@@ -1,0 +1,131 @@
+package org.jpos.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.options.Option;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Extension for the JPOSPlugin
+ */
+public interface JPOSPluginExtension {
+
+    /**
+     * Target configuration to use
+     */
+    @Input
+    @Option(option = "devel", description = "The target configuration to use")
+    Property<String> getTarget();
+
+    /**
+     * If the task that add the git metadata is executed
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain revision.properties info")
+    Property<Boolean> getAddGitRevision();
+
+    /**
+     * If the task that add the build time metadata is executed
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain buildinfo.properties file")
+    Property<Boolean> getAddBuildTime();
+
+
+    /**
+     * The jar that will be built
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain buildinfo.properties file")
+    Property<String> getArchiveJarName();
+
+    /**
+     * Where to put the war
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain buildinfo.properties file")
+    Property<String> getArchiveWarName();
+
+    /**
+     * Where to put the artifacts
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain buildinfo.properties file")
+    Property<String> getInstallDir();
+
+    /**
+     * The dist folder that will be used as a source
+     */
+    @Input
+    @Option(option = "true", description = "If the resulting dist folder should contain buildinfo.properties file")
+    Property<String> getDistDir();
+
+    @Internal
+    MapProperty<String, Object> getProperties();
+
+    default void loadFromProject(Project project) throws IOException {
+
+        initConventions(project);
+        File cfgFile = new File(project.getRootDir(), String.format("%s.properties", getTarget().get()));
+        if (cfgFile.exists()) {
+            try (FileInputStream fis = new FileInputStream(cfgFile)) {
+                Properties props = new Properties();
+                props.load(fis);
+                Map<String, Object> startingProps = new HashMap<>();
+                props.forEach((k, v) -> {
+                    switch (k.toString()) {
+                        case "archiveJarName":
+                        case "jarname":
+                            getArchiveJarName().set(v.toString());
+                            break;
+                        case "archiveWarName":
+                            getArchiveWarName().set(v.toString());
+                            break;
+                        case "installDir":
+                            getInstallDir().set(v.toString());
+                            break;
+                        case "distDir":
+                            getDistDir().set(v.toString());
+                            break;
+                        default:
+                            startingProps.put(k.toString(), v);
+                            break;
+                    }
+                });
+                getProperties().set(startingProps);
+            }
+        }
+    }
+
+    default Map<String, String> asMap() {
+        HashMap<String, String> toRet = new HashMap<>();
+        for (Map.Entry<String, Object> entry : getProperties().get().entrySet()) {
+            toRet.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+        }
+        toRet.put("archiveJarName", getArchiveJarName().get());
+        toRet.put("archiveWarName", getArchiveWarName().get());
+        toRet.put("installDir", getInstallDir().get());
+        toRet.put("distDir", getDistDir().get());
+        toRet.put("jarname", getArchiveJarName().get());
+        return toRet;
+    }
+
+    default void initConventions(Project project) {
+        getTarget().convention("devel");
+        getAddBuildTime().convention(true);
+        getAddGitRevision().convention(true);
+        getArchiveJarName().convention(String.format("%s-%s.jar", project.getName(), project.getVersion()));
+        getArchiveWarName().convention(String.format("%s-%s.war", project.getName(), project.getVersion()));
+        getInstallDir().convention(String.format("%s/install/%s", project.getBuildDir(), project.getName()));
+        getDistDir().convention("src/dist");
+    }
+}


### PR DESCRIPTION
The plugin can now be configured using a 'jpos' directive in the .gradle file:

```groovy
jpos {
    target = "devel"
    addGitRevision = true
    addBuildTime = true
    archiveJarName = "${project_name}-${version}.jar"
    archiveWarName = "${project_name}-${version}.war"
    installDir = build/install/${project_name}
    distDir = src/dist
}
```

A non trivial refactor of the plugin was made to ensure that those properties
can be configured and used as described in the README.

This commit also makes this plugin compatible with gradle 8, so it fixes #3

The configurability of git revision data also fixes #5.

And it can be a workaround for #7 using a different distDir.

Signed-off-by: Arturo Volpe <avolpe@fintech.works>
