### PR TITLE
Better handling of token replacement properties

### DIFF
--- a/src/main/java/org/jpos/gradle/JPOSPlugin.java
+++ b/src/main/java/org/jpos/gradle/JPOSPlugin.java
@@ -1,6 +1,6 @@
 /*
  * jPOS Project [http://jpos.org]
- * Copyright (C) 2000-2022 jPOS Software SRL
+ * Copyright (C) 2000-2023 jPOS Software SRL
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -54,8 +54,11 @@ public class JPOSPlugin implements Plugin<Project> {
 
             ExtensionContainer ext = project.getExtensions();
 
-            if (project.hasProperty("target"))
+            if (project.hasProperty("target")) {
                 extension.getTarget().set("" + project.property("target"));
+            }
+
+            extension.getProperties().put("target", extension.getTarget().get());
             ext.add("target", extension.getTarget().get());
 
             var buildTimestampTask = createBuildTimestampTask(project);
@@ -198,7 +201,10 @@ public class JPOSPlugin implements Plugin<Project> {
     private CopySpec distFiltered(Project project, JPOSPluginExtension targetConfiguration) {
         Map<String, Map<String, String>> hm = new HashMap<>();
         var tokens = targetConfiguration.asMap();
-        tokens.put("target", targetConfiguration.getTarget().get());
+        project.getExtensions().getExtraProperties().getProperties().forEach(
+            (k,v) -> tokens.put(k, v.toString())
+        );
+
         hm.put("tokens", tokens);
         File distDir = new File(project.getProjectDir(), targetConfiguration.getDistDir().get());
         return project.copySpec(copy -> copy

--- a/src/main/java/org/jpos/gradle/JPOSPlugin.java
+++ b/src/main/java/org/jpos/gradle/JPOSPlugin.java
@@ -230,7 +230,12 @@ public class JPOSPlugin implements Plugin<Project> {
 
     private CopySpec distBinFiltered(Project project, JPOSPluginExtension targetConfiguration) {
         Map<String, Map<String, String>> hm = new HashMap<>();
-        hm.put("tokens", targetConfiguration.asMap());
+        var tokens = targetConfiguration.asMap();
+        project.getExtensions().getExtraProperties().getProperties().forEach(
+            (k,v) -> tokens.put(k, v.toString())
+        );
+
+        hm.put("tokens", tokens);
         File distBinDir = new File(project.getProjectDir(), targetConfiguration.getDistDir().get() + "/bin");
         return project.copySpec(copy -> copy
                 .from(distBinDir)

--- a/src/main/java/org/jpos/gradle/JPOSPluginExtension.java
+++ b/src/main/java/org/jpos/gradle/JPOSPluginExtension.java
@@ -128,7 +128,7 @@ public interface JPOSPluginExtension {
                             break;
                     }
                 });
-                getProperties().set(startingProps);
+                getProperties().putAll(startingProps);
             }
         }
     }


### PR DESCRIPTION
- Do not reset previously-configured extension properties when loading from a `<target>.properties` file.
   Use `getProperties().putAll()` method instead of `set()`, to add the properties loaded from the file.

- Also add all the `ext` properties to the token replacement map.
   This includes properties defined in the build file, as well as ones passed through the **gradle command line** like `-Psome_prop=some_val`
