### PR TITLE
upgrade jgit and handle worktrees

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.4.0.202509020913-r'
 }
 
 


### PR DESCRIPTION
Eclipse jGIT has been upgraded to 7.40.
The newer 7.x versions handle correctamente a local worktree that has a `.git` file pointing to the `.git` dir of the parent repo in the filesystem.

The obtaining of the `revision` hash has been simplified a bit, and it's now using 9 hash digits to support for some larger repos that need to avoid hash collision.

I tested the correct generation of the `revision.properties`  file under these situations

* A project with no `.git` at all (just a simple directory for an unversioned project), it will just generate `revision=unknown`.
* A project with `git init` so there is a `.git` but **not a single commit yet**.  
* A project where I'm standing at a random (detached) commit.  In this case the `revision` will be the abbrev(9) hash and the `branch` will be the full hash.  It's not bad, and it's an unusual situation
* A project which is a `git worktree` of a parent repo, so `.git` is a file refering to the path of the real `.git` dir.  This case works well.
* Finally, a normal local repo who owns the `.git` dir.  This would be the standard case and everything still works as it used to.
