### PR TITLE
Add installResources task

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
-java=25.0.2-amzn
+java=26-amzn
 gradle=9.5.0
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ jpos {
 
 This will generate always the same jar (and dist folder)
 
+## Installing embedded module resources
+
+The plugin provides an `installResources` task that runs `org.jpos.q2.install.Install` and extracts resources packaged under `META-INF/q2/installs`.
+
+By default, resources are installed into `jpos.installDir`:
+
+```bash
+./gradlew installResources
+```
+
+You can override the target directory with the task option:
+
+```bash
+./gradlew installResources --outputDir=/path/to/install
+```
+
 ## Per-target excludes
 
 If for some reason we want the plugin to exclude some files for a given target, we can add `<targetName>.exclude`.

--- a/src/functionalTest/java/org/jpos/gradle/ExtraPathsFunctionalTest.java
+++ b/src/functionalTest/java/org/jpos/gradle/ExtraPathsFunctionalTest.java
@@ -195,6 +195,36 @@ class ExtraPathsFunctionalTest {
             "Should not contain docs/ without extraPaths. Files: " + files);
     }
 
+    @Test
+    void installResourcesUsesDefaultAndCustomOutputDir() throws Exception {
+        writeFile(
+            "src/main/resources/META-INF/q2/installs/deploy/99_test.xml",
+            "<deploy>test</deploy>\n"
+        );
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("installResources", "--stacktrace")
+            .build();
+
+        Path defaultOutput = projectDir.toPath().resolve("build/install/test-app/deploy/99_test.xml");
+        assertTrue(Files.isRegularFile(defaultOutput),
+            "installResources should use jpos.installDir by default");
+        assertEquals("<deploy>test</deploy>\n", Files.readString(defaultOutput));
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("installResources", "--outputDir=build/custom-install", "--stacktrace")
+            .build();
+
+        Path customOutput = projectDir.toPath().resolve("build/custom-install/deploy/99_test.xml");
+        assertTrue(Files.isRegularFile(customOutput),
+            "installResources should accept --outputDir");
+        assertEquals("<deploy>test</deploy>\n", Files.readString(customOutput));
+    }
+
     // --- helpers ---
 
     private void writeFile(String relativePath, String content) throws IOException {

--- a/src/main/java/org/jpos/gradle/InstallResourcesTask.java
+++ b/src/main/java/org/jpos/gradle/InstallResourcesTask.java
@@ -1,0 +1,51 @@
+/*
+ * jPOS Project [http://jpos.org]
+ * Copyright (C) 2000-2026 jPOS Software SRL
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jpos.gradle;
+
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.work.DisableCachingByDefault;
+
+import javax.inject.Inject;
+
+/**
+ * Installs q2 module resources embedded under META-INF/q2/installs.
+ */
+@DisableCachingByDefault(because = "Resource installation is an imperative JavaExec task")
+public abstract class InstallResourcesTask extends JavaExec {
+    private final Property<String> outputDir;
+
+    @Inject
+    public InstallResourcesTask(ObjectFactory objects) {
+        outputDir = objects.property(String.class);
+    }
+
+    @Input
+    public Property<String> getOutputDir() {
+        return outputDir;
+    }
+
+    @Option(option = "outputDir", description = "Output directory for installed resources. Defaults to jpos.installDir.")
+    public void setOutputDir(String outputDir) {
+        this.outputDir.set(outputDir);
+    }
+}

--- a/src/main/java/org/jpos/gradle/JPOSPlugin.java
+++ b/src/main/java/org/jpos/gradle/JPOSPlugin.java
@@ -113,6 +113,7 @@ public class JPOSPlugin implements Plugin<Project> {
                     LOGGER.debug("Loaded config for the jpos plugin {} -  {}", pr.getName(), extension.asMap());
                     configureJar(project, extension);
                     createInstallAppTask(project, extension);
+                    createInstallResourcesTask(project, extension);
                     createDistTask(project, extension, "dist", Tar.class);
                     createDistTask(project, extension, "zip", Zip.class);
                     createDistNcTask(project, extension, "distnc", Tar.class);
@@ -152,6 +153,37 @@ public class JPOSPlugin implements Plugin<Project> {
             );
             installApp.into(new File(targetConfiguration.getInstallDir().get()));
             installApp.getOutputs().upToDateWhen(_ -> false);
+        });
+    }
+
+    /**
+     * Creates the 'installResources' task, which extracts q2 module resources embedded in
+     * META-INF/q2/installs into a target directory using org.jpos.q2.install.Install.
+     *
+     * @param project the Gradle project
+     * @param targetConfiguration the configuration settings for the jPOS application
+     */
+    private void createInstallResourcesTask(Project project, JPOSPluginExtension targetConfiguration) {
+        project.getTasks().register("installResources", InstallResourcesTask.class, installResources -> {
+            installResources.setDescription("Installs embedded jPOS resources from META-INF/q2/installs.");
+            installResources.setGroup(GROUP_NAME);
+            installResources.dependsOn(project.getTasks().getByName("installApp"));
+
+            SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+            SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+            TaskProvider<Jar> jarTask = project.getTasks().named("jar", Jar.class);
+
+            installResources.setClasspath(
+              mainSourceSet.getRuntimeClasspath().plus(
+                project.files(jarTask.flatMap(Jar::getArchiveFile))
+              )
+            );
+            installResources.getMainClass().set("org.jpos.q2.install.Install");
+            installResources.getOutputDir().convention(targetConfiguration.getInstallDir());
+            installResources.doFirst(_ -> installResources.setArgs(
+              List.of("--outputDir=" + installResources.getOutputDir().get())
+            ));
+            installResources.getOutputs().upToDateWhen(_ -> false);
         });
     }
 


### PR DESCRIPTION
## Summary
- align .sdkmanrc with jPOS (Java 26, Gradle 9.5.0)
- add an installResources task that runs org.jpos.q2.install.Install
- default outputDir to jpos.installDir and support --outputDir override
- document the task and add functional coverage

## Verification
- ./gradlew clean check