### PR TITLE
Upgrade Gradle wrapper to 9.5.1

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,2 @@
-java=26-amzn
-gradle=9.5.0
-
+java=26.0.1-amzn
+gradle=9.5.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper from 9.5.0 to 9.5.1.
- Align `.sdkmanrc` with the current Java 26.0.1 / Gradle 9.5.1 toolchain.

## Verification
- `sdk env`
- `JAVA_TOOL_OPTIONS=-Xshare:off ./gradlew clean build --warning-mode all`
- Build log scan found no warning/error/deprecation matches.
